### PR TITLE
feat: remove recent circuits on landing page

### DIFF
--- a/app/controllers/circuitverse_controller.rb
+++ b/app/controllers/circuitverse_controller.rb
@@ -4,20 +4,6 @@ class CircuitverseController < ApplicationController
   MAXIMUM_FEATURED_CIRCUITS = 3
 
   def index
-    @projects = Project.select(:id, :author_id, :image_preview, :name, :slug)
-                       .public_and_not_forked
-                       .where.not(image_preview: "default.png")
-                       .order(id: :desc)
-                       .includes(:author)
-                       .limit(Project.per_page)
-
-    page = params[:page].to_i
-    @projects = if page.positive?
-      @projects.paginate(page: page)
-    else
-      @projects.paginate(page: nil)
-    end
-
     @featured_circuits = Project.joins(:featured_circuit)
                                 .order("featured_circuits.created_at DESC")
                                 .includes(:author)
@@ -43,6 +29,28 @@ class CircuitverseController < ApplicationController
                    img: "examples/FlipFlop_n.jpg" },
                  { name: "ALU 74LS181 by Ananth Shreekumar", id: "users/126/projects/252",
                    img: "examples/ALU_n.jpg" }]
+  end
+
+  def recent_projects
+    @projects = Project.select(:id, :author_id, :image_preview, :name, :slug)
+                       .public_and_not_forked
+                       .where.not(image_preview: "default.png")
+                       .order(id: :desc)
+                       .includes(:author)
+                       .limit(Project.per_page)
+
+    page = params[:page].to_i
+    @projects = if page.positive?
+      @projects.paginate(page: page)
+    else
+      @projects.paginate(page: nil)
+    end
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @projects }
+      format.js
+    end
   end
 
   def tos; end

--- a/app/views/circuitverse/index.html.erb
+++ b/app/views/circuitverse/index.html.erb
@@ -192,36 +192,20 @@
         </div>
       </div>
     </div>
-    <% cache "recent-projects-#{params[:page]}", expires_in: 10.minutes do %>
-      <div class="container" id="recent">
-        <div class="row center-row home-circuit-card-row">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-            <h3><%= t("circuitverse.index.recent_circuits.main_heading") %></h3>
-            <p><%= t("circuitverse.index.recent_circuits.main_description") %></p>
-          </div>
-        </div>
-        <div class="row center-row justify-content-center">
-          <% @projects.each do |project| %>
-            <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
-              <div class="card circuit-card">
-                <%= image_tag project_image_preview(project, current_user), alt: project.name, class: "card-img-top circuit-card-image" %>
-                <div class="card-footer circuit-card-footer">
-                  <div class="circuit-card-name">
-                    <p><%= project.name %></p>
-                    <span class="tooltiptext"><%= project.name %></span>
-                  </div>
-                  <a class="btn primary-button circuit-card-primary-button" target="_blank" href="<%= user_project_url(project.author, project) %>"><%= t("view") %></a>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-        <div class="container pagination-cont">
-          <%= will_paginate @projects, renderer: PaginateRenderer %>
+    <div class="container" id="recent">
+      <div class="row center-row home-circuit-card-row">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <h3><%= t("circuitverse.index.recent_circuits.main_heading") %></h3>
+          <p><%= t("circuitverse.index.recent_circuits.main_description") %></p>
         </div>
       </div>
-    <% end %>
-
+      <div class="row center-row">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <%= render_button(t("circuitverse.index.recent_projects"), link: "/recent_projects", class: "primary-button homepage-primary-button-feature") %>
+          
+        </div>
+      </div>
+    </div>
     <% if user_signed_in? %>
     <script>
         if(localStorage.getItem("recover_login")){

--- a/app/views/circuitverse/recent_projects.html.erb
+++ b/app/views/circuitverse/recent_projects.html.erb
@@ -1,0 +1,31 @@
+<div>
+  <% cache "recent-projects-#{params[:page]}", expires_in: 10.minutes do %>
+  <div class="container" id="recent">
+    <div class="row center-row home-circuit-card-row">
+      <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <h3><%= t("circuitverse.index.recent_circuits.main_heading") %></h3>
+        <p><%= t("circuitverse.index.recent_circuits.main_description") %></p>
+      </div>
+    </div>
+    <div class="row center-row justify-content-center">
+      <% @projects.each do |project| %>
+        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+          <div class="card circuit-card">
+            <%= image_tag project_image_preview(project, current_user), alt: project.name, class: "card-img-top circuit-card-image" %>
+            <div class="card-footer circuit-card-footer">
+              <div class="circuit-card-name">
+                <p><%= project.name %></p>
+                <span class="tooltiptext"><%= project.name %></span>
+              </div>
+              <%= render_button(t("view"), link: user_project_url(project.author, project), class: "primary-button circuit-card-primary-button", target: "_blank") %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <div class="container pagination-cont">
+      <%= will_paginate @projects, renderer: PaginateRenderer %>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
   get  "/tos", to: "circuitverse#tos"
   get  "/teachers", to: "circuitverse#teachers"
   get  "/contribute", to: "circuitverse#contribute"
-
+  get  "/recent_projects", to: "circuitverse#recent_projects"
   #announcements
   resources :announcements, except: %i[show]
 


### PR DESCRIPTION
Fixes # Remove "Recent Circuits on Landing Page

#### Describe the changes you have made in this PR -

Enhance the user experience on the CircuitVerse platform by removing the "Recent Circuits on Landing Page" feature, which has become less relevant due to the high volume of new circuits being created per hour. Instead, a dedicated page, "/recent_projects," will be created to display recent projects. This change will streamline the landing page and improve its focus on core functionalities
### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
